### PR TITLE
Fix duplicate rule in subfolder Traefik config

### DIFF
--- a/docker-compose/subfolderWithSSL/docker-compose.yml
+++ b/docker-compose/subfolderWithSSL/docker-compose.yml
@@ -32,10 +32,9 @@ services:
       - '127.0.0.1:5678:5678'
     labels:
       - traefik.enable=true
-      - traefik.http.routers.n8n.rule=Host(`${DOMAIN_NAME}`)
       - traefik.http.routers.n8n.tls=true
       - traefik.http.routers.n8n.entrypoints=websecure
-      - 'traefik.http.routers.n8n.rule=PathPrefix(`/${SUBFOLDER}{regex:$$|/.*}`)'
+      - "traefik.http.routers.n8n.rule=Host(`${DOMAIN_NAME}`) && PathPrefix(`/${SUBFOLDER}{regex:$$|/.*}`)"
       - 'traefik.http.middlewares.n8n-stripprefix.stripprefix.prefixes=/${SUBFOLDER}'
       - 'traefik.http.routers.n8n.middlewares=n8n-stripprefix'
       - traefik.http.routers.n8n.tls.certresolver=mytlschallenge


### PR DESCRIPTION
## Summary
- fix duplicate Traefik rule by combining host and path checks

## Testing
- `python3.12 - <<'PY'
import yaml
import sys
try:
    yaml.safe_load(open('docker-compose/subfolderWithSSL/docker-compose.yml'))
    print('YAML OK')
except Exception as e:
    print('YAML ERROR', e)
PY`


------
https://chatgpt.com/codex/tasks/task_e_684b46b4daa08326b945edb64f6a13f4