### PR TITLE
Add env examples and update docs

### DIFF
--- a/docker-caddy/.env.example
+++ b/docker-caddy/.env.example
@@ -1,0 +1,18 @@
+# Replace <directory-path> with the path where you created folders earlier
+DATA_FOLDER=/<directory-path>/n8n-docker-caddy
+
+# The top level domain to serve from, this should be the same as the subdomain you created above
+DOMAIN_NAME=example.com
+
+# The subdomain to serve from
+SUBDOMAIN=n8n
+
+# DOMAIN_NAME and SUBDOMAIN combined decide where n8n will be reachable from
+# above example would result in: https://n8n.example.com
+
+# Optional timezone to set which gets used by Cron-Node by default
+# If not set New York time will be used
+GENERIC_TIMEZONE=Europe/Berlin
+
+# The email address to use for the SSL certificate creation
+SSL_EMAIL=example@example.com

--- a/docker-caddy/README.md
+++ b/docker-caddy/README.md
@@ -7,6 +7,8 @@ Get up and running with n8n on the following platforms:
 
 If you have questions after trying the tutorials, check out the [forums](https://community.n8n.io/).
 
+Before running the stack, copy `.env.example` to `.env` and update the values to match your environment.
+
 ## Prerequisites
 
 Self-hosting n8n requires technical knowledge, including:

--- a/docker-compose/subfolderWithSSL/.env.example
+++ b/docker-compose/subfolderWithSSL/.env.example
@@ -1,0 +1,14 @@
+# Directory where persistent data and certificates will be stored
+DATA_FOLDER=/path/to/n8n-data
+
+# Email address used for Let's Encrypt registration
+SSL_EMAIL=example@example.com
+
+# Domain name that should serve n8n
+DOMAIN_NAME=example.com
+
+# Subfolder (without slashes) under which n8n is reachable
+SUBFOLDER=n8n
+
+# Path n8n uses internally, usually "/${SUBFOLDER}/"
+N8N_PATH=/n8n/

--- a/docker-compose/subfolderWithSSL/README.md
+++ b/docker-compose/subfolderWithSSL/README.md
@@ -7,7 +7,7 @@ Starts n8n and deploys it on a subfolder
 To start n8n in a subfolder simply start docker-compose by executing the following
 command in the current folder.
 
-**IMPORTANT:** But before you do that change the default users and passwords in the `.env` file!
+**IMPORTANT:** Before starting, copy `.env.example` to `.env` and update the values to match your setup.
 
 ```
 docker-compose up -d

--- a/docker-compose/withPostgres/.env.example
+++ b/docker-compose/withPostgres/.env.example
@@ -1,0 +1,10 @@
+# Database superuser credentials
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=postgres
+
+# Default database used by n8n
+POSTGRES_DB=n8n
+
+# Non-privileged user n8n will connect as
+POSTGRES_NON_ROOT_USER=n8n
+POSTGRES_NON_ROOT_PASSWORD=n8n

--- a/docker-compose/withPostgres/README.md
+++ b/docker-compose/withPostgres/README.md
@@ -7,7 +7,7 @@ Starts n8n with PostgreSQL as database.
 To start n8n with PostgreSQL simply start docker-compose by executing the following
 command in the current folder.
 
-**IMPORTANT:** But before you do that change the default users and passwords in the [`.env`](.env) file!
+**IMPORTANT:** Before starting, copy `.env.example` to `.env` and update the values in the new file.
 
 ```
 docker-compose up -d

--- a/docker-compose/withPostgresAndWorker/.env.example
+++ b/docker-compose/withPostgresAndWorker/.env.example
@@ -1,0 +1,13 @@
+# Database superuser credentials
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=postgres
+
+# Default database used by n8n
+POSTGRES_DB=n8n
+
+# Non-privileged user n8n will connect as
+POSTGRES_NON_ROOT_USER=n8n
+POSTGRES_NON_ROOT_PASSWORD=n8n
+
+# Encryption key for n8n. Generate a random string and keep it safe.
+ENCRYPTION_KEY=

--- a/docker-compose/withPostgresAndWorker/README.md
+++ b/docker-compose/withPostgresAndWorker/README.md
@@ -7,7 +7,7 @@ Starts n8n with PostgreSQL as database, and the Worker as a separate container.
 To start n8n simply start docker-compose by executing the following
 command in the current folder.
 
-**IMPORTANT:** But before you do that change the default users and passwords in the [`.env`](.env) file!
+**IMPORTANT:** Before starting, copy `.env.example` to `.env` and edit the values accordingly.
 
 ```
 docker-compose up -d


### PR DESCRIPTION
## Summary
- add `.env.example` for docker-caddy and all docker-compose setups
- update README files to instruct copying `.env.example`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684da397c9f08326819a8390ca4a2c67