### PR TITLE
Add AI operations automation workflows

### DIFF
--- a/workflows/README.md
+++ b/workflows/README.md
@@ -1,0 +1,33 @@
+# AI Operations Assistant Workflows
+
+This directory contains the n8n workflows used to recreate the "AI Employee" automation shown in the reference screenshots.
+
+## Files
+
+- `ai-operations-assistant.json` – master orchestrator that runs daily, plans tasks with OpenAI, dispatches to MCP toolkits, and composes the daily executive update.
+- `google-calendar-mcp-tools.json` – Google Calendar actions (create/update/delete events, availability lookup).
+- `google-drive-mcp-tools.json` – Google Drive automation (upload files, create folders, manage permissions, mirror templates).
+- `google-mail-mcp-tools.json` – Gmail tooling (summaries, replies, drafts, label management).
+- `linkedin-mcp-tools.json` – LinkedIn utilities powered by Apify or custom webhooks (inbox scrape, DM send, post publishing, profile sync).
+- `twitter-mcp-tools.json` – Twitter/X toolkit (post, DM, search mentions, refresh metrics).
+- `utility-mcp-tools.json` – General purpose helpers (OpenAI summarization, Clearbit enrichment, Airtable sync, Slack notifications).
+
+## Usage
+
+1. Import the six MCP tool workflows first so that their names are available to the main orchestrator.
+2. Import `ai-operations-assistant.json` and update the credential references (OpenAI, Google, Slack, Clearbit, Airtable, Apify, LinkedIn automation).
+3. Set environment variables used in expressions:
+   - `AI_EMPLOYEE_REPORT_RECIPIENT`
+   - `GCAL_PRIMARY`
+   - `GDRIVE_DEALS_FOLDER`
+   - `APIFY_LINKEDIN_INBOX_TASK`
+   - `APIFY_TOKEN`
+   - `LINKEDIN_AUTOMATION_URL`
+   - `LINKEDIN_AUTOMATION_TOKEN`
+   - `TWITTER_HANDLE`
+   - `AIRTABLE_APP_ID`
+   - `AIRTABLE_PIPELINE_TABLE`
+   - `SLACK_ALERT_CHANNEL`
+4. Enable the workflows and test the daily execution via the `Daily Kickoff` node.
+
+Each workflow uses workflow static data to persist context (persona, objectives, reporting recipient, task map, results) so parallel executions remain isolated.

--- a/workflows/ai-operations-assistant.json
+++ b/workflows/ai-operations-assistant.json
@@ -1,0 +1,964 @@
+{
+  "name": "AI Operations Assistant",
+  "nodes": [
+    {
+      "parameters": {
+        "triggerTimes": {
+          "item": [
+            {
+              "mode": "everyDay",
+              "hour": 6,
+              "minute": 0
+            }
+          ]
+        }
+      },
+      "id": "c80fa236-37bd-41fe-892e-22946d1c6301",
+      "name": "Daily Kickoff",
+      "type": "n8n-nodes-base.cron",
+      "typeVersion": 2,
+      "position": [
+        -1200,
+        -160
+      ]
+    },
+    {
+      "parameters": {
+        "values": {
+          "string": [
+            {
+              "name": "agentPersona",
+              "value": "You are an AI operations chief of staff responsible for keeping the executive team informed, triaging inbound leads, and managing outbound comms."
+            },
+            {
+              "name": "reportingEmail",
+              "value": "{{ $env.AI_EMPLOYEE_REPORT_RECIPIENT || 'ops@example.com' }}"
+            }
+          ],
+          "json": [
+            {
+              "name": "objectives",
+              "value": "={\"daily\":[\"Summarize unread Gmail threads tagged #Priority\",\"Reconcile Google Calendar availability\",\"Process LinkedIn and Twitter DMs\",\"Sync deal artifacts to Google Drive\",\"Draft social posts from approved talking points\"]}"
+            }
+          ]
+        },
+        "options": {
+          "dotNotation": true
+        }
+      },
+      "id": "4f9936b9-c511-4088-89b2-f21990d13401",
+      "name": "Set Context",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 2,
+      "position": [
+        -1000,
+        -160
+      ]
+    },
+    {
+      "parameters": {
+        "functionCode": "const data = items[0]?.json || {};\nconst store = this.getWorkflowStaticData('global');\nstore.agentPersona = data.agentPersona;\nstore.objectives = data.objectives;\nstore.reportingEmail = data.reportingEmail;\nreturn items;"
+      },
+      "id": "ac941dc3-0baf-45e4-ac89-17f1764d153b",
+      "name": "Function - Cache Persona",
+      "type": "n8n-nodes-base.function",
+      "typeVersion": 2,
+      "position": [
+        -820,
+        -160
+      ]
+    },
+    {
+      "parameters": {
+        "resource": "chat",
+        "operation": "chat",
+        "model": "gpt-4o-mini",
+        "systemMessage": "Plan the next block of work for our AI employee using the provided context. Output valid JSON with a tasks array where each task includes: id, domain (calendar|drive|gmail|linkedin|twitter|utility), action, priority (P0-P2), summary, metadata. Include only actionable items we should execute via automation.",
+        "messages": [
+          {
+            "message": "={{$json}}",
+            "sender": "user"
+          }
+        ],
+        "additionalFields": {
+          "responseFormat": "json_object"
+        }
+      },
+      "id": "071d3464-f62e-4014-b172-69904fd24fa5",
+      "name": "OpenAI - Plan Day",
+      "type": "n8n-nodes-base.openAi",
+      "typeVersion": 3,
+      "position": [
+        -780,
+        -160
+      ]
+    },
+    {
+      "parameters": {
+        "functionCode": "const raw = items[0]?.json?.choices?.[0]?.message?.content ?? '{}';\nlet payload;\ntry {\n  payload = typeof raw === 'string' ? JSON.parse(raw) : raw;\n} catch (error) {\n  throw new Error('Unable to parse agent plan JSON: ' + error.message + ' -> ' + raw);\n}\nconst tasks = payload.tasks ?? [];\nreturn tasks.map(task => ({ json: { task } }));"
+      },
+      "id": "bd672367-98a3-4b76-a81d-14daddf7a653",
+      "name": "Function - Expand Tasks",
+      "type": "n8n-nodes-base.function",
+      "typeVersion": 2,
+      "position": [
+        -520,
+        -160
+      ]
+    },
+    {
+      "parameters": {
+        "functionCode": "const map = new Map();\nfor (const item of items) {\n  const task = item.json.task;\n  const domain = (task.domain || 'utility').toLowerCase();\n  if (!map.has(domain)) {\n    map.set(domain, []);\n  }\n  map.get(domain).push(task);\n}\nconst globalData = this.getWorkflowStaticData('global');\nglobalData.taskMap = {};\nglobalData.results = [];\nfor (const [domain, list] of map.entries()) {\n  globalData.taskMap[domain] = list;\n}\nconst domains = ['calendar','drive','gmail','linkedin','twitter','utility'];\nreturn domains.map(domain => ({ json: { domain, tasks: globalData.taskMap[domain] || [] } }));"
+      },
+      "id": "d3d135f1-4ca4-4e82-a97e-42c608a2a0db",
+      "name": "Function - Cache Task Map",
+      "type": "n8n-nodes-base.function",
+      "typeVersion": 2,
+      "position": [
+        -320,
+        -160
+      ]
+    },
+    {
+      "parameters": {
+        "propertyName": "domain",
+        "dataType": "string",
+        "rules": [
+          {
+            "operation": "equal",
+            "value": "calendar"
+          },
+          {
+            "operation": "equal",
+            "value": "drive"
+          },
+          {
+            "operation": "equal",
+            "value": "gmail"
+          },
+          {
+            "operation": "equal",
+            "value": "linkedin"
+          },
+          {
+            "operation": "equal",
+            "value": "twitter"
+          }
+        ]
+      },
+      "id": "5d49b11a-87ad-43f4-a1d7-f0eddcb0a324",
+      "name": "Switch - Route Domain",
+      "type": "n8n-nodes-base.switch",
+      "typeVersion": 2,
+      "position": [
+        -100,
+        -160
+      ]
+    },
+    {
+      "parameters": {
+        "workflowName": "Google Calendar MCP Tools",
+        "options": {
+          "waitForResponse": true,
+          "noWebhookResponse": true
+        }
+      },
+      "id": "b5a61234-749b-4149-8e1f-502e938181b8",
+      "name": "Run Calendar Tools",
+      "type": "n8n-nodes-base.executeWorkflow",
+      "typeVersion": 1,
+      "position": [
+        160,
+        -320
+      ]
+    },
+    {
+      "parameters": {
+        "workflowName": "Google Drive MCP Tools",
+        "options": {
+          "waitForResponse": true,
+          "noWebhookResponse": true
+        }
+      },
+      "id": "18393627-baec-40b1-b774-84eb04da5b73",
+      "name": "Run Drive Tools",
+      "type": "n8n-nodes-base.executeWorkflow",
+      "typeVersion": 1,
+      "position": [
+        160,
+        -160
+      ]
+    },
+    {
+      "parameters": {
+        "workflowName": "Google Mail MCP Tools",
+        "options": {
+          "waitForResponse": true,
+          "noWebhookResponse": true
+        }
+      },
+      "id": "f1e33893-ab13-47be-a294-99c90e51d99a",
+      "name": "Run Gmail Tools",
+      "type": "n8n-nodes-base.executeWorkflow",
+      "typeVersion": 1,
+      "position": [
+        160,
+        0
+      ]
+    },
+    {
+      "parameters": {
+        "workflowName": "LinkedIn MCP Tools",
+        "options": {
+          "waitForResponse": true,
+          "noWebhookResponse": true
+        }
+      },
+      "id": "1d4739eb-ac4b-4551-9fe4-1937e3c726fd",
+      "name": "Run LinkedIn Tools",
+      "type": "n8n-nodes-base.executeWorkflow",
+      "typeVersion": 1,
+      "position": [
+        160,
+        160
+      ]
+    },
+    {
+      "parameters": {
+        "workflowName": "Twitter MCP Tools",
+        "options": {
+          "waitForResponse": true,
+          "noWebhookResponse": true
+        }
+      },
+      "id": "70c8f7b7-d89e-4fe0-b4e4-cc724d01b346",
+      "name": "Run Twitter Tools",
+      "type": "n8n-nodes-base.executeWorkflow",
+      "typeVersion": 1,
+      "position": [
+        160,
+        320
+      ]
+    },
+    {
+      "parameters": {
+        "workflowName": "Utility MCP Tools",
+        "options": {
+          "waitForResponse": true,
+          "noWebhookResponse": true
+        }
+      },
+      "id": "4cb5532a-6798-4063-871c-7773a6d8ea56",
+      "name": "Run Utility Tools",
+      "type": "n8n-nodes-base.executeWorkflow",
+      "typeVersion": 1,
+      "position": [
+        160,
+        480
+      ]
+    },
+    {
+      "parameters": {
+        "functionCode": "const globalData = this.getWorkflowStaticData('global');\nconst results = globalData.results || [];\nreturn [{ json: { results } }];"
+      },
+      "id": "f8c6c19c-3342-4a10-a55a-673bc6f71c74",
+      "name": "Function - Gather Results",
+      "type": "n8n-nodes-base.function",
+      "typeVersion": 2,
+      "position": [
+        1460,
+        120
+      ]
+    },
+    {
+      "parameters": {
+        "functionCode": "const globalData = this.getWorkflowStaticData('global');\nconst results = items[0].json.results || [];\nconst objectives = Array.isArray(globalData.objectives?.daily) ? globalData.objectives.daily : [];\nconst persona = globalData.agentPersona || 'an AI operations chief of staff';\nreturn [{ json: { summaryPrompt: `You are ${persona}. Draft a status update that summarizes these domain results (${JSON.stringify(results)}). Highlight blockers, upcoming deadlines, and next actions. Objectives: ${objectives.join(', ')}` } }];"
+      },
+      "id": "ecac059f-5336-482f-aad7-a8c7d32d2612",
+      "name": "Function - Build Summary Prompt",
+      "type": "n8n-nodes-base.function",
+      "typeVersion": 2,
+      "position": [
+        1660,
+        120
+      ]
+    },
+    {
+      "parameters": {
+        "resource": "chat",
+        "operation": "chat",
+        "model": "gpt-4o-mini",
+        "systemMessage": "Write crisp async status updates with bullet lists and callouts for blockers.",
+        "messages": [
+          {
+            "message": "={{$json.summaryPrompt}}",
+            "sender": "user"
+          }
+        ]
+      },
+      "id": "3d04fdc5-3df4-4549-8016-95a5fc860ecf",
+      "name": "OpenAI - Draft Executive Update",
+      "type": "n8n-nodes-base.openAi",
+      "typeVersion": 3,
+      "position": [
+        1860,
+        120
+      ]
+    },
+    {
+      "parameters": {
+        "resource": "message",
+        "operation": "send",
+        "additionalFields": {
+          "subject": "AI Employee Daily Update",
+          "toList": "={{$workflow.staticData.global.reportingEmail || $env.AI_EMPLOYEE_REPORT_RECIPIENT}}",
+          "text": "={{$json.body || $json}}"
+        },
+        "messageBody": "={{$json.choices[0].message.content}}"
+      },
+      "id": "9db691d2-ea19-4c99-867e-f6ffe0a08898",
+      "name": "Gmail - Send Update",
+      "type": "n8n-nodes-base.gmail",
+      "typeVersion": 1,
+      "position": [
+        2060,
+        120
+      ]
+    },
+    {
+      "parameters": {
+        "functionCode": "const store = this.getWorkflowStaticData('global');\nconst sourceList = store.taskMap?.calendar || [];\nreturn items.map((item, index) => {\n  const paired = item.pairedItem?.item ?? index;\n  const source = sourceList[paired] || item.json.task || {};\n  if (item.json.result && item.json.domain) {\n    return { json: { domain: item.json.domain, action: item.json.action, task: item.json.task, result: item.json.result } };\n  }\n  if (item.json.domain && item.json.result === undefined && !sourceList.length) {\n    return { json: { domain: item.json.domain, action: item.json.action, task: item.json.task, result: item.json } };\n  }\n  return { json: { domain: source.domain || 'calendar', action: source.action, task: source, result: item.json } };\n});"
+      },
+      "id": "0607fffc-e50c-4b21-80fc-28884aecf8be",
+      "name": "Function - Normalize Calendar Result",
+      "type": "n8n-nodes-base.function",
+      "typeVersion": 2,
+      "position": [
+        360,
+        -320
+      ]
+    },
+    {
+      "parameters": {
+        "functionCode": "const globalData = this.getWorkflowStaticData('global');\nif (!globalData.results) globalData.results = [];\nfor (const item of items) {\n  const payload = item.json || {};\n  if (payload.domain) {\n    globalData.results.push(payload);\n  }\n}\nreturn [{ json: { domain: 'calendar', processed: items.length } }];"
+      },
+      "id": "2d7a7040-7ba7-4e2b-93ad-0d4f77a2e8ac",
+      "name": "Function - Collect Calendar Result",
+      "type": "n8n-nodes-base.function",
+      "typeVersion": 2,
+      "position": [
+        580,
+        -320
+      ]
+    },
+    {
+      "parameters": {
+        "functionCode": "const store = this.getWorkflowStaticData('global');\nconst sourceList = store.taskMap?.drive || [];\nreturn items.map((item, index) => {\n  const paired = item.pairedItem?.item ?? index;\n  const source = sourceList[paired] || item.json.task || {};\n  if (item.json.result && item.json.domain) {\n    return { json: { domain: item.json.domain, action: item.json.action, task: item.json.task, result: item.json.result } };\n  }\n  if (item.json.domain && item.json.result === undefined && !sourceList.length) {\n    return { json: { domain: item.json.domain, action: item.json.action, task: item.json.task, result: item.json } };\n  }\n  return { json: { domain: source.domain || 'drive', action: source.action, task: source, result: item.json } };\n});"
+      },
+      "id": "ae3efc24-8a61-453c-976e-33a5423d163c",
+      "name": "Function - Normalize Drive Result",
+      "type": "n8n-nodes-base.function",
+      "typeVersion": 2,
+      "position": [
+        360,
+        -160
+      ]
+    },
+    {
+      "parameters": {
+        "functionCode": "const globalData = this.getWorkflowStaticData('global');\nif (!globalData.results) globalData.results = [];\nfor (const item of items) {\n  const payload = item.json || {};\n  if (payload.domain) {\n    globalData.results.push(payload);\n  }\n}\nreturn [{ json: { domain: 'drive', processed: items.length } }];"
+      },
+      "id": "18f94fe5-976a-4bcf-9980-e638c4bd9531",
+      "name": "Function - Collect Drive Result",
+      "type": "n8n-nodes-base.function",
+      "typeVersion": 2,
+      "position": [
+        580,
+        -160
+      ]
+    },
+    {
+      "parameters": {
+        "functionCode": "const store = this.getWorkflowStaticData('global');\nconst sourceList = store.taskMap?.gmail || [];\nreturn items.map((item, index) => {\n  const paired = item.pairedItem?.item ?? index;\n  const source = sourceList[paired] || item.json.task || {};\n  if (item.json.result && item.json.domain) {\n    return { json: { domain: item.json.domain, action: item.json.action, task: item.json.task, result: item.json.result } };\n  }\n  if (item.json.domain && item.json.result === undefined && !sourceList.length) {\n    return { json: { domain: item.json.domain, action: item.json.action, task: item.json.task, result: item.json } };\n  }\n  return { json: { domain: source.domain || 'gmail', action: source.action, task: source, result: item.json } };\n});"
+      },
+      "id": "ca63f194-53e5-4482-9f81-eced76914bd5",
+      "name": "Function - Normalize Gmail Result",
+      "type": "n8n-nodes-base.function",
+      "typeVersion": 2,
+      "position": [
+        360,
+        0
+      ]
+    },
+    {
+      "parameters": {
+        "functionCode": "const globalData = this.getWorkflowStaticData('global');\nif (!globalData.results) globalData.results = [];\nfor (const item of items) {\n  const payload = item.json || {};\n  if (payload.domain) {\n    globalData.results.push(payload);\n  }\n}\nreturn [{ json: { domain: 'gmail', processed: items.length } }];"
+      },
+      "id": "3007dddd-c266-497b-a70d-8470ca3b9bc8",
+      "name": "Function - Collect Gmail Result",
+      "type": "n8n-nodes-base.function",
+      "typeVersion": 2,
+      "position": [
+        580,
+        0
+      ]
+    },
+    {
+      "parameters": {
+        "functionCode": "const store = this.getWorkflowStaticData('global');\nconst sourceList = store.taskMap?.linkedin || [];\nreturn items.map((item, index) => {\n  const paired = item.pairedItem?.item ?? index;\n  const source = sourceList[paired] || item.json.task || {};\n  if (item.json.result && item.json.domain) {\n    return { json: { domain: item.json.domain, action: item.json.action, task: item.json.task, result: item.json.result } };\n  }\n  if (item.json.domain && item.json.result === undefined && !sourceList.length) {\n    return { json: { domain: item.json.domain, action: item.json.action, task: item.json.task, result: item.json } };\n  }\n  return { json: { domain: source.domain || 'linkedin', action: source.action, task: source, result: item.json } };\n});"
+      },
+      "id": "5dea58bb-8f6e-4faa-8af3-272524e3de30",
+      "name": "Function - Normalize Linkedin Result",
+      "type": "n8n-nodes-base.function",
+      "typeVersion": 2,
+      "position": [
+        360,
+        160
+      ]
+    },
+    {
+      "parameters": {
+        "functionCode": "const globalData = this.getWorkflowStaticData('global');\nif (!globalData.results) globalData.results = [];\nfor (const item of items) {\n  const payload = item.json || {};\n  if (payload.domain) {\n    globalData.results.push(payload);\n  }\n}\nreturn [{ json: { domain: 'linkedin', processed: items.length } }];"
+      },
+      "id": "6e598797-346b-44f3-8d08-e8828fad6fce",
+      "name": "Function - Collect Linkedin Result",
+      "type": "n8n-nodes-base.function",
+      "typeVersion": 2,
+      "position": [
+        580,
+        160
+      ]
+    },
+    {
+      "parameters": {
+        "functionCode": "const store = this.getWorkflowStaticData('global');\nconst sourceList = store.taskMap?.twitter || [];\nreturn items.map((item, index) => {\n  const paired = item.pairedItem?.item ?? index;\n  const source = sourceList[paired] || item.json.task || {};\n  if (item.json.result && item.json.domain) {\n    return { json: { domain: item.json.domain, action: item.json.action, task: item.json.task, result: item.json.result } };\n  }\n  if (item.json.domain && item.json.result === undefined && !sourceList.length) {\n    return { json: { domain: item.json.domain, action: item.json.action, task: item.json.task, result: item.json } };\n  }\n  return { json: { domain: source.domain || 'twitter', action: source.action, task: source, result: item.json } };\n});"
+      },
+      "id": "b2867524-c8a6-4044-9279-108f1f899dd2",
+      "name": "Function - Normalize Twitter Result",
+      "type": "n8n-nodes-base.function",
+      "typeVersion": 2,
+      "position": [
+        360,
+        320
+      ]
+    },
+    {
+      "parameters": {
+        "functionCode": "const globalData = this.getWorkflowStaticData('global');\nif (!globalData.results) globalData.results = [];\nfor (const item of items) {\n  const payload = item.json || {};\n  if (payload.domain) {\n    globalData.results.push(payload);\n  }\n}\nreturn [{ json: { domain: 'twitter', processed: items.length } }];"
+      },
+      "id": "8ce89204-00f7-469a-8ce6-743f7942abde",
+      "name": "Function - Collect Twitter Result",
+      "type": "n8n-nodes-base.function",
+      "typeVersion": 2,
+      "position": [
+        580,
+        320
+      ]
+    },
+    {
+      "parameters": {
+        "functionCode": "const store = this.getWorkflowStaticData('global');\nconst sourceList = store.taskMap?.utility || [];\nreturn items.map((item, index) => {\n  const paired = item.pairedItem?.item ?? index;\n  const source = sourceList[paired] || item.json.task || {};\n  if (item.json.result && item.json.domain) {\n    return { json: { domain: item.json.domain, action: item.json.action, task: item.json.task, result: item.json.result } };\n  }\n  if (item.json.domain && item.json.result === undefined && !sourceList.length) {\n    return { json: { domain: item.json.domain, action: item.json.action, task: item.json.task, result: item.json } };\n  }\n  return { json: { domain: source.domain || 'utility', action: source.action, task: source, result: item.json } };\n});"
+      },
+      "id": "92386737-b04f-4705-9ad6-b6621129e3e8",
+      "name": "Function - Normalize Utility Result",
+      "type": "n8n-nodes-base.function",
+      "typeVersion": 2,
+      "position": [
+        360,
+        480
+      ]
+    },
+    {
+      "parameters": {
+        "functionCode": "const globalData = this.getWorkflowStaticData('global');\nif (!globalData.results) globalData.results = [];\nfor (const item of items) {\n  const payload = item.json || {};\n  if (payload.domain) {\n    globalData.results.push(payload);\n  }\n}\nreturn [{ json: { domain: 'utility', processed: items.length } }];"
+      },
+      "id": "e7af54b4-7457-47af-bc51-10eb28f59889",
+      "name": "Function - Collect Utility Result",
+      "type": "n8n-nodes-base.function",
+      "typeVersion": 2,
+      "position": [
+        580,
+        480
+      ]
+    },
+    {
+      "parameters": {
+        "mode": "passThrough",
+        "passThrough": "input1",
+        "join": "wait"
+      },
+      "id": "84c15e34-1eb2-4000-ac02-01f567eacfe1",
+      "name": "Merge Calendar & Drive",
+      "type": "n8n-nodes-base.merge",
+      "typeVersion": 2,
+      "position": [
+        620,
+        -200
+      ]
+    },
+    {
+      "parameters": {
+        "mode": "passThrough",
+        "passThrough": "input1",
+        "join": "wait"
+      },
+      "id": "3893464a-57c3-4bdd-80c7-a44862c8d2a9",
+      "name": "Merge CD & Gmail",
+      "type": "n8n-nodes-base.merge",
+      "typeVersion": 2,
+      "position": [
+        780,
+        -120
+      ]
+    },
+    {
+      "parameters": {
+        "mode": "passThrough",
+        "passThrough": "input1",
+        "join": "wait"
+      },
+      "id": "4feb4757-a0fb-467b-b054-88f6c55f40a4",
+      "name": "Merge CDG & LinkedIn",
+      "type": "n8n-nodes-base.merge",
+      "typeVersion": 2,
+      "position": [
+        940,
+        -40
+      ]
+    },
+    {
+      "parameters": {
+        "mode": "passThrough",
+        "passThrough": "input1",
+        "join": "wait"
+      },
+      "id": "24d63b6e-b5f4-4771-ae37-62920435445a",
+      "name": "Merge CDGL & Twitter",
+      "type": "n8n-nodes-base.merge",
+      "typeVersion": 2,
+      "position": [
+        1100,
+        40
+      ]
+    },
+    {
+      "parameters": {
+        "mode": "passThrough",
+        "passThrough": "input1",
+        "join": "wait"
+      },
+      "id": "e94846f3-58d3-4a2f-ab08-215066b15e04",
+      "name": "Merge All Tools",
+      "type": "n8n-nodes-base.merge",
+      "typeVersion": 2,
+      "position": [
+        1260,
+        120
+      ]
+    }
+  ],
+  "connections": {
+    "Daily Kickoff": {
+      "main": [
+        [
+          {
+            "node": "Set Context",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Set Context": {
+      "main": [
+        [
+          {
+            "node": "Function - Cache Persona",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "OpenAI - Plan Day": {
+      "main": [
+        [
+          {
+            "node": "Function - Expand Tasks",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Function - Expand Tasks": {
+      "main": [
+        [
+          {
+            "node": "Function - Cache Task Map",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Switch - Route Domain": {
+      "main": [
+        [
+          {
+            "node": "Run Calendar Tools",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Run Drive Tools",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Run Gmail Tools",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Run LinkedIn Tools",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Run Twitter Tools",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Run Utility Tools",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Run Calendar Tools": {
+      "main": [
+        [
+          {
+            "node": "Function - Normalize Calendar Result",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Run Drive Tools": {
+      "main": [
+        [
+          {
+            "node": "Function - Normalize Drive Result",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Run Gmail Tools": {
+      "main": [
+        [
+          {
+            "node": "Function - Normalize Gmail Result",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Run LinkedIn Tools": {
+      "main": [
+        [
+          {
+            "node": "Function - Normalize Linkedin Result",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Run Twitter Tools": {
+      "main": [
+        [
+          {
+            "node": "Function - Normalize Twitter Result",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Run Utility Tools": {
+      "main": [
+        [
+          {
+            "node": "Function - Normalize Utility Result",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Function - Gather Results": {
+      "main": [
+        [
+          {
+            "node": "Function - Build Summary Prompt",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Function - Build Summary Prompt": {
+      "main": [
+        [
+          {
+            "node": "OpenAI - Draft Executive Update",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "OpenAI - Draft Executive Update": {
+      "main": [
+        [
+          {
+            "node": "Gmail - Send Update",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Function - Normalize Calendar Result": {
+      "main": [
+        [
+          {
+            "node": "Function - Collect Calendar Result",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Function - Normalize Drive Result": {
+      "main": [
+        [
+          {
+            "node": "Function - Collect Drive Result",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Function - Normalize Gmail Result": {
+      "main": [
+        [
+          {
+            "node": "Function - Collect Gmail Result",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Function - Normalize Linkedin Result": {
+      "main": [
+        [
+          {
+            "node": "Function - Collect Linkedin Result",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Function - Normalize Twitter Result": {
+      "main": [
+        [
+          {
+            "node": "Function - Collect Twitter Result",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Function - Normalize Utility Result": {
+      "main": [
+        [
+          {
+            "node": "Function - Collect Utility Result",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Merge Calendar & Drive": {
+      "main": [
+        [
+          {
+            "node": "Merge CD & Gmail",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Merge CD & Gmail": {
+      "main": [
+        [
+          {
+            "node": "Merge CDG & LinkedIn",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Merge CDG & LinkedIn": {
+      "main": [
+        [
+          {
+            "node": "Merge CDGL & Twitter",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Merge CDGL & Twitter": {
+      "main": [
+        [
+          {
+            "node": "Merge All Tools",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Merge All Tools": {
+      "main": [
+        [
+          {
+            "node": "Function - Gather Results",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Function - Collect Calendar Result": {
+      "main": [
+        [
+          {
+            "node": "Merge Calendar & Drive",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Function - Collect Drive Result": {
+      "main": [
+        [
+          {
+            "node": "Merge Calendar & Drive",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Function - Collect Gmail Result": {
+      "main": [
+        [
+          {
+            "node": "Merge CD & Gmail",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Function - Collect Linkedin Result": {
+      "main": [
+        [
+          {
+            "node": "Merge CDG & LinkedIn",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Function - Collect Twitter Result": {
+      "main": [
+        [
+          {
+            "node": "Merge CDGL & Twitter",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Function - Collect Utility Result": {
+      "main": [
+        [
+          {
+            "node": "Merge All Tools",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Function - Cache Persona": {
+      "main": [
+        [
+          {
+            "node": "OpenAI - Plan Day",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Function - Cache Task Map": {
+      "main": [
+        [
+          {
+            "node": "Switch - Route Domain",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "pinData": {}
+}

--- a/workflows/google-calendar-mcp-tools.json
+++ b/workflows/google-calendar-mcp-tools.json
@@ -1,0 +1,367 @@
+{
+  "name": "Google Calendar MCP Tools",
+  "nodes": [
+    {
+      "parameters": {},
+      "id": "55074a75-766a-404e-beab-ad7936fdc2dd",
+      "name": "Workflow Trigger",
+      "type": "n8n-nodes-base.workflowTrigger",
+      "typeVersion": 1,
+      "position": [
+        -820,
+        -20
+      ]
+    },
+    {
+      "parameters": {
+        "functionCode": "const input = items[0]?.json || {};\nconst tasks = Array.isArray(input.tasks) ? input.tasks : [];\nconst store = this.getWorkflowStaticData('global');\nstore.tasks = tasks;\nreturn [{ json: { domain: input.domain || 'calendar', tasks } }];"
+      },
+      "id": "2e5fa271-2ccd-446c-9252-e80226028b94",
+      "name": "Function - Extract Tasks",
+      "type": "n8n-nodes-base.function",
+      "typeVersion": 2,
+      "position": [
+        -600,
+        -20
+      ]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "number": [
+            {
+              "value1": "={{$json.tasks.length}}",
+              "operation": "larger",
+              "value2": 0
+            }
+          ]
+        }
+      },
+      "id": "44b165fc-5ede-4295-bc17-3d32311e6a56",
+      "name": "IF - Has Tasks",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [
+        -420,
+        -20
+      ]
+    },
+    {
+      "parameters": {
+        "functionCode": "const tasks = items[0].json.tasks || [];\nreturn tasks.map(task => ({ json: task }));"
+      },
+      "id": "05c9c27a-ecf7-4dd9-bc44-9bfb997bf811",
+      "name": "Function - Fan Out",
+      "type": "n8n-nodes-base.function",
+      "typeVersion": 2,
+      "position": [
+        -220,
+        -120
+      ]
+    },
+    {
+      "parameters": {
+        "propertyName": "action",
+        "dataType": "string",
+        "rules": [
+          {
+            "operation": "equal",
+            "value": "create_event"
+          },
+          {
+            "operation": "equal",
+            "value": "update_event"
+          },
+          {
+            "operation": "equal",
+            "value": "delete_event"
+          },
+          {
+            "operation": "equal",
+            "value": "list_availability"
+          }
+        ]
+      },
+      "id": "3f739446-7fef-4664-920f-087922ee7772",
+      "name": "Switch - Route Action",
+      "type": "n8n-nodes-base.switch",
+      "typeVersion": 2,
+      "position": [
+        0,
+        -120
+      ]
+    },
+    {
+      "parameters": {
+        "resource": "event",
+        "operation": "create",
+        "calendar": "={{$json.metadata.calendarId || $env.GCAL_PRIMARY || 'primary'}}",
+        "summary": "={{$json.summary}}",
+        "start": "={{$json.metadata.start}}",
+        "end": "={{$json.metadata.end}}",
+        "additionalFields": {
+          "description": "={{$json.metadata.description || $json.summary}}",
+          "location": "={{$json.metadata.location}}",
+          "attendees": "={{$json.metadata.attendees}}",
+          "sendUpdates": "all"
+        }
+      },
+      "id": "0e6442cb-8f1f-4354-9078-803612ed05ad",
+      "name": "Google Calendar - Create Event",
+      "type": "n8n-nodes-base.googleCalendar",
+      "typeVersion": 2,
+      "position": [
+        220,
+        -300
+      ]
+    },
+    {
+      "parameters": {
+        "resource": "event",
+        "operation": "update",
+        "calendar": "={{$json.metadata.calendarId || $env.GCAL_PRIMARY || 'primary'}}",
+        "eventId": "={{$json.metadata.eventId}}",
+        "updateFields": {
+          "summary": "={{$json.summary}}",
+          "description": "={{$json.metadata.description}}",
+          "location": "={{$json.metadata.location}}",
+          "start": "={{$json.metadata.start}}",
+          "end": "={{$json.metadata.end}}",
+          "attendees": "={{$json.metadata.attendees}}",
+          "sendUpdates": "all"
+        }
+      },
+      "id": "2180564d-cc2d-4829-97ba-06171f9467d0",
+      "name": "Google Calendar - Update Event",
+      "type": "n8n-nodes-base.googleCalendar",
+      "typeVersion": 2,
+      "position": [
+        220,
+        -140
+      ]
+    },
+    {
+      "parameters": {
+        "resource": "event",
+        "operation": "delete",
+        "calendar": "={{$json.metadata.calendarId || $env.GCAL_PRIMARY || 'primary'}}",
+        "eventId": "={{$json.metadata.eventId}}",
+        "options": {
+          "sendUpdates": "all"
+        }
+      },
+      "id": "cbd45cb3-331f-41b6-a681-dda8f039e54e",
+      "name": "Google Calendar - Delete Event",
+      "type": "n8n-nodes-base.googleCalendar",
+      "typeVersion": 2,
+      "position": [
+        220,
+        20
+      ]
+    },
+    {
+      "parameters": {
+        "resource": "event",
+        "operation": "getAll",
+        "calendar": "={{$json.metadata.calendarId || $env.GCAL_PRIMARY || 'primary'}}",
+        "returnAll": true,
+        "options": {
+          "timeMin": "={{$json.metadata.start || $now.startOf('day')}}",
+          "timeMax": "={{$json.metadata.end || $now.plus({ days: 7 })}}",
+          "query": "={{$json.metadata.query}}"
+        }
+      },
+      "id": "4b794e6d-1769-4bf4-b48a-56467a1c7e1f",
+      "name": "Google Calendar - List Availability",
+      "type": "n8n-nodes-base.googleCalendar",
+      "typeVersion": 2,
+      "position": [
+        220,
+        180
+      ]
+    },
+    {
+      "parameters": {
+        "functionCode": "const store = this.getWorkflowStaticData('global');\nreturn items.map(item => {\n  const index = item.pairedItem?.item ?? 0;\n  const source = store.tasks?.[index] || {};\n  return { json: { domain: source.domain || 'calendar', action: source.action, task: source, result: item.json } };\n});"
+      },
+      "id": "bfbbeed3-244b-4fa4-a38b-92a52c0689b7",
+      "name": "Function - Format Action Result",
+      "type": "n8n-nodes-base.function",
+      "typeVersion": 2,
+      "position": [
+        460,
+        -140
+      ]
+    },
+    {
+      "parameters": {
+        "values": {
+          "string": [
+            {
+              "name": "domain",
+              "value": "calendar"
+            }
+          ],
+          "json": [
+            {
+              "name": "result",
+              "value": "={\"status\":\"skipped\",\"reason\":\"No calendar tasks queued.\"}"
+            }
+          ]
+        }
+      },
+      "id": "ede85593-cbaa-48ad-af96-703df84b9c64",
+      "name": "Set - No Tasks",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 2,
+      "position": [
+        -220,
+        120
+      ]
+    }
+  ],
+  "connections": {
+    "Workflow Trigger": {
+      "main": [
+        [
+          {
+            "node": "Function - Extract Tasks",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Function - Extract Tasks": {
+      "main": [
+        [
+          {
+            "node": "IF - Has Tasks",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "IF - Has Tasks": {
+      "main": [
+        [
+          {
+            "node": "Function - Fan Out",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Set - No Tasks",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Function - Fan Out": {
+      "main": [
+        [
+          {
+            "node": "Switch - Route Action",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Switch - Route Action": {
+      "main": [
+        [
+          {
+            "node": "Google Calendar - Create Event",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Google Calendar - Update Event",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Google Calendar - Delete Event",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Google Calendar - List Availability",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Google Calendar - Create Event": {
+      "main": [
+        [
+          {
+            "node": "Function - Format Action Result",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Google Calendar - Update Event": {
+      "main": [
+        [
+          {
+            "node": "Function - Format Action Result",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Google Calendar - Delete Event": {
+      "main": [
+        [
+          {
+            "node": "Function - Format Action Result",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Google Calendar - List Availability": {
+      "main": [
+        [
+          {
+            "node": "Function - Format Action Result",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Set - No Tasks": {
+      "main": [
+        [
+          {
+            "node": "Function - Format Action Result",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "pinData": {}
+}

--- a/workflows/google-drive-mcp-tools.json
+++ b/workflows/google-drive-mcp-tools.json
@@ -1,0 +1,344 @@
+{
+  "name": "Google Drive MCP Tools",
+  "nodes": [
+    {
+      "parameters": {},
+      "id": "1c4ee6a1-f6b6-48f8-a6ef-0b875eff967a",
+      "name": "Workflow Trigger",
+      "type": "n8n-nodes-base.workflowTrigger",
+      "typeVersion": 1,
+      "position": [
+        -820,
+        -60
+      ]
+    },
+    {
+      "parameters": {
+        "functionCode": "const input = items[0]?.json || {};\nconst tasks = Array.isArray(input.tasks) ? input.tasks : [];\nconst store = this.getWorkflowStaticData('global');\nstore.tasks = tasks;\nreturn [{ json: { domain: input.domain || 'drive', tasks } }];"
+      },
+      "id": "69e12243-03c3-4c66-89f6-ea60dd0aaa7b",
+      "name": "Function - Extract Tasks",
+      "type": "n8n-nodes-base.function",
+      "typeVersion": 2,
+      "position": [
+        -600,
+        -60
+      ]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "number": [
+            {
+              "value1": "={{$json.tasks.length}}",
+              "operation": "larger",
+              "value2": 0
+            }
+          ]
+        }
+      },
+      "id": "70545089-2fb6-4ce9-b5bb-2d47f6c3d599",
+      "name": "IF - Has Tasks",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [
+        -420,
+        -60
+      ]
+    },
+    {
+      "parameters": {
+        "functionCode": "const tasks = items[0].json.tasks || [];\nreturn tasks.map(task => ({ json: task }));"
+      },
+      "id": "88a0734b-1e2d-43ca-a298-71c98214aebd",
+      "name": "Function - Fan Out",
+      "type": "n8n-nodes-base.function",
+      "typeVersion": 2,
+      "position": [
+        -220,
+        -160
+      ]
+    },
+    {
+      "parameters": {
+        "propertyName": "action",
+        "dataType": "string",
+        "rules": [
+          {
+            "operation": "equal",
+            "value": "upload_file"
+          },
+          {
+            "operation": "equal",
+            "value": "create_folder"
+          },
+          {
+            "operation": "equal",
+            "value": "update_permissions"
+          },
+          {
+            "operation": "equal",
+            "value": "mirror_deal_folder"
+          }
+        ]
+      },
+      "id": "263c113f-ac9d-4a33-a2f8-2cc776912311",
+      "name": "Switch - Route Action",
+      "type": "n8n-nodes-base.switch",
+      "typeVersion": 2,
+      "position": [
+        0,
+        -160
+      ]
+    },
+    {
+      "parameters": {
+        "operation": "upload",
+        "binaryData": false,
+        "fileContent": "={{$json.metadata.fileContent}}",
+        "fileName": "={{$json.metadata.fileName}}",
+        "parents": "={{$json.metadata.parentId || $env.GDRIVE_DEALS_FOLDER}}"
+      },
+      "id": "72dda3ea-3510-4202-ba66-6156884ddf52",
+      "name": "Google Drive - Upload File",
+      "type": "n8n-nodes-base.googleDrive",
+      "typeVersion": 2,
+      "position": [
+        220,
+        -360
+      ]
+    },
+    {
+      "parameters": {
+        "operation": "createFolder",
+        "name": "={{$json.metadata.folderName}}",
+        "parents": "={{$json.metadata.parentId || $env.GDRIVE_DEALS_FOLDER}}"
+      },
+      "id": "6e45cde7-a548-4b19-bbe4-811a6cb6c900",
+      "name": "Google Drive - Create Folder",
+      "type": "n8n-nodes-base.googleDrive",
+      "typeVersion": 2,
+      "position": [
+        220,
+        -200
+      ]
+    },
+    {
+      "parameters": {
+        "operation": "share",
+        "fileId": "={{$json.metadata.fileId}}",
+        "role": "={{$json.metadata.role || 'writer'}}",
+        "type": "={{$json.metadata.type || 'user'}}",
+        "emailAddress": "={{$json.metadata.email}}",
+        "sendNotificationEmail": true
+      },
+      "id": "7b194180-21ef-455c-9fba-487392fdca49",
+      "name": "Google Drive - Update Permissions",
+      "type": "n8n-nodes-base.googleDrive",
+      "typeVersion": 2,
+      "position": [
+        220,
+        -40
+      ]
+    },
+    {
+      "parameters": {
+        "operation": "copy",
+        "fileId": "={{$json.metadata.templateId}}",
+        "parents": "={{$json.metadata.parentId || $env.GDRIVE_DEALS_FOLDER}}",
+        "name": "={{$json.metadata.fileName}}"
+      },
+      "id": "3af871c7-9a5c-4ed6-831a-86d82bcce20b",
+      "name": "Google Drive - Mirror Deal Folder",
+      "type": "n8n-nodes-base.googleDrive",
+      "typeVersion": 2,
+      "position": [
+        220,
+        120
+      ]
+    },
+    {
+      "parameters": {
+        "functionCode": "const store = this.getWorkflowStaticData('global');\nreturn items.map(item => {\n  const index = item.pairedItem?.item ?? 0;\n  const source = store.tasks?.[index] || {};\n  return { json: { domain: source.domain || 'drive', action: source.action, task: source, result: item.json } };\n});"
+      },
+      "id": "59696122-78e6-4c36-bd04-6aae96257127",
+      "name": "Function - Format Action Result",
+      "type": "n8n-nodes-base.function",
+      "typeVersion": 2,
+      "position": [
+        460,
+        -120
+      ]
+    },
+    {
+      "parameters": {
+        "values": {
+          "string": [
+            {
+              "name": "domain",
+              "value": "drive"
+            }
+          ],
+          "json": [
+            {
+              "name": "result",
+              "value": "={\"status\":\"skipped\",\"reason\":\"No drive tasks queued.\"}"
+            }
+          ]
+        }
+      },
+      "id": "0409866f-bd13-4beb-9159-d3b7bb850c38",
+      "name": "Set - No Tasks",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 2,
+      "position": [
+        -220,
+        60
+      ]
+    }
+  ],
+  "connections": {
+    "Workflow Trigger": {
+      "main": [
+        [
+          {
+            "node": "Function - Extract Tasks",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Function - Extract Tasks": {
+      "main": [
+        [
+          {
+            "node": "IF - Has Tasks",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "IF - Has Tasks": {
+      "main": [
+        [
+          {
+            "node": "Function - Fan Out",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Set - No Tasks",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Function - Fan Out": {
+      "main": [
+        [
+          {
+            "node": "Switch - Route Action",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Switch - Route Action": {
+      "main": [
+        [
+          {
+            "node": "Google Drive - Upload File",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Google Drive - Create Folder",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Google Drive - Update Permissions",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Google Drive - Mirror Deal Folder",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Google Drive - Upload File": {
+      "main": [
+        [
+          {
+            "node": "Function - Format Action Result",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Google Drive - Create Folder": {
+      "main": [
+        [
+          {
+            "node": "Function - Format Action Result",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Google Drive - Update Permissions": {
+      "main": [
+        [
+          {
+            "node": "Function - Format Action Result",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Google Drive - Mirror Deal Folder": {
+      "main": [
+        [
+          {
+            "node": "Function - Format Action Result",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Set - No Tasks": {
+      "main": [
+        [
+          {
+            "node": "Function - Format Action Result",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "pinData": {}
+}

--- a/workflows/google-mail-mcp-tools.json
+++ b/workflows/google-mail-mcp-tools.json
@@ -1,0 +1,387 @@
+{
+  "name": "Google Mail MCP Tools",
+  "nodes": [
+    {
+      "parameters": {},
+      "id": "1af896ee-f12e-43c6-83f4-cc6ab9d15532",
+      "name": "Workflow Trigger",
+      "type": "n8n-nodes-base.workflowTrigger",
+      "typeVersion": 1,
+      "position": [
+        -820,
+        -40
+      ]
+    },
+    {
+      "parameters": {
+        "functionCode": "const input = items[0]?.json || {};\nconst tasks = Array.isArray(input.tasks) ? input.tasks : [];\nconst store = this.getWorkflowStaticData('global');\nstore.tasks = tasks;\nreturn [{ json: { domain: input.domain || 'gmail', tasks } }];"
+      },
+      "id": "a3099c5b-442b-44e5-8570-e562de2a1eef",
+      "name": "Function - Extract Tasks",
+      "type": "n8n-nodes-base.function",
+      "typeVersion": 2,
+      "position": [
+        -600,
+        -40
+      ]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "number": [
+            {
+              "value1": "={{$json.tasks.length}}",
+              "operation": "larger",
+              "value2": 0
+            }
+          ]
+        }
+      },
+      "id": "b12b3124-567f-4abc-b3d6-0e4097dc7454",
+      "name": "IF - Has Tasks",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [
+        -420,
+        -40
+      ]
+    },
+    {
+      "parameters": {
+        "functionCode": "const tasks = items[0].json.tasks || [];\nreturn tasks.map(task => ({ json: task }));"
+      },
+      "id": "162b2e1d-92e3-4c4e-9aaf-567b08779eae",
+      "name": "Function - Fan Out",
+      "type": "n8n-nodes-base.function",
+      "typeVersion": 2,
+      "position": [
+        -220,
+        -140
+      ]
+    },
+    {
+      "parameters": {
+        "propertyName": "action",
+        "dataType": "string",
+        "rules": [
+          {
+            "operation": "equal",
+            "value": "summarize_thread"
+          },
+          {
+            "operation": "equal",
+            "value": "reply_to_thread"
+          },
+          {
+            "operation": "equal",
+            "value": "draft_email"
+          },
+          {
+            "operation": "equal",
+            "value": "label_thread"
+          }
+        ]
+      },
+      "id": "4086c754-71be-4922-8cbe-bb400c472ced",
+      "name": "Switch - Route Action",
+      "type": "n8n-nodes-base.switch",
+      "typeVersion": 2,
+      "position": [
+        0,
+        -140
+      ]
+    },
+    {
+      "parameters": {
+        "resource": "message",
+        "operation": "get",
+        "messageId": "={{$json.metadata.messageId}}",
+        "additionalFields": {
+          "format": "full"
+        }
+      },
+      "id": "7d61f02b-c44c-44e4-a60a-edcd77c19201",
+      "name": "Gmail - Fetch Thread",
+      "type": "n8n-nodes-base.gmail",
+      "typeVersion": 1,
+      "position": [
+        220,
+        -320
+      ]
+    },
+    {
+      "parameters": {
+        "resource": "message",
+        "operation": "reply",
+        "messageId": "={{$json.metadata.messageId}}",
+        "additionalFields": {
+          "text": "={{$json.metadata.body}}",
+          "subject": "={{$json.metadata.subject}}"
+        }
+      },
+      "id": "c33b5e09-03fe-444d-8c78-be7c1b294232",
+      "name": "Gmail - Reply",
+      "type": "n8n-nodes-base.gmail",
+      "typeVersion": 1,
+      "position": [
+        220,
+        -160
+      ]
+    },
+    {
+      "parameters": {
+        "resource": "message",
+        "operation": "create",
+        "messageBody": "={{$json.metadata.body}}",
+        "additionalFields": {
+          "toList": "={{$json.metadata.to}}",
+          "ccList": "={{$json.metadata.cc}}",
+          "bccList": "={{$json.metadata.bcc}}",
+          "subject": "={{$json.metadata.subject}}",
+          "send": false
+        }
+      },
+      "id": "98af83d4-5861-4fc6-8bcb-89d24e130cc3",
+      "name": "Gmail - Draft",
+      "type": "n8n-nodes-base.gmail",
+      "typeVersion": 1,
+      "position": [
+        220,
+        0
+      ]
+    },
+    {
+      "parameters": {
+        "resource": "message",
+        "operation": "addLabel",
+        "messageId": "={{$json.metadata.messageId}}",
+        "labelIds": [
+          "={{$json.metadata.labelId || $env.GMAIL_PRIORITY_LABEL}}"
+        ]
+      },
+      "id": "08a20c07-13aa-4a8a-8d5a-18f0e0d8da80",
+      "name": "Gmail - Apply Label",
+      "type": "n8n-nodes-base.gmail",
+      "typeVersion": 1,
+      "position": [
+        220,
+        160
+      ]
+    },
+    {
+      "parameters": {
+        "resource": "text",
+        "operation": "summarize",
+        "model": "gpt-4o-mini",
+        "messages": [
+          {
+            "message": "Summarize this Gmail thread for the executive team and highlight action items: {{$json}}",
+            "sender": "user"
+          }
+        ]
+      },
+      "id": "39127df1-149b-488f-b9ab-1dc7ad083a6d",
+      "name": "OpenAI - Summarize Thread",
+      "type": "n8n-nodes-base.openAi",
+      "typeVersion": 3,
+      "position": [
+        420,
+        -320
+      ]
+    },
+    {
+      "parameters": {
+        "functionCode": "const store = this.getWorkflowStaticData('global');\nreturn items.map(item => {\n  const index = item.pairedItem?.item ?? 0;\n  const source = store.tasks?.[index] || {};\n  return { json: { domain: source.domain || 'gmail', action: source.action, task: source, result: item.json } };\n});"
+      },
+      "id": "064e866a-0086-4571-916f-c3a5536cf40a",
+      "name": "Function - Format Action Result",
+      "type": "n8n-nodes-base.function",
+      "typeVersion": 2,
+      "position": [
+        640,
+        -120
+      ]
+    },
+    {
+      "parameters": {
+        "values": {
+          "string": [
+            {
+              "name": "domain",
+              "value": "gmail"
+            }
+          ],
+          "json": [
+            {
+              "name": "result",
+              "value": "={\"status\":\"skipped\",\"reason\":\"No gmail tasks queued.\"}"
+            }
+          ]
+        }
+      },
+      "id": "9393424f-9731-4e39-9e04-5d1d2e5e1ebc",
+      "name": "Set - No Tasks",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 2,
+      "position": [
+        -220,
+        60
+      ]
+    }
+  ],
+  "connections": {
+    "Workflow Trigger": {
+      "main": [
+        [
+          {
+            "node": "Function - Extract Tasks",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Function - Extract Tasks": {
+      "main": [
+        [
+          {
+            "node": "IF - Has Tasks",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "IF - Has Tasks": {
+      "main": [
+        [
+          {
+            "node": "Function - Fan Out",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Set - No Tasks",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Function - Fan Out": {
+      "main": [
+        [
+          {
+            "node": "Switch - Route Action",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Switch - Route Action": {
+      "main": [
+        [
+          {
+            "node": "Gmail - Fetch Thread",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Gmail - Reply",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Gmail - Draft",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Gmail - Apply Label",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Gmail - Fetch Thread": {
+      "main": [
+        [
+          {
+            "node": "OpenAI - Summarize Thread",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "OpenAI - Summarize Thread": {
+      "main": [
+        [
+          {
+            "node": "Function - Format Action Result",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Gmail - Reply": {
+      "main": [
+        [
+          {
+            "node": "Function - Format Action Result",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Gmail - Draft": {
+      "main": [
+        [
+          {
+            "node": "Function - Format Action Result",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Gmail - Apply Label": {
+      "main": [
+        [
+          {
+            "node": "Function - Format Action Result",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Set - No Tasks": {
+      "main": [
+        [
+          {
+            "node": "Function - Format Action Result",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "pinData": {}
+}

--- a/workflows/linkedin-mcp-tools.json
+++ b/workflows/linkedin-mcp-tools.json
@@ -1,0 +1,379 @@
+{
+  "name": "LinkedIn MCP Tools",
+  "nodes": [
+    {
+      "parameters": {},
+      "id": "39bcc677-3bd9-49e8-86a6-0d369e84c033",
+      "name": "Workflow Trigger",
+      "type": "n8n-nodes-base.workflowTrigger",
+      "typeVersion": 1,
+      "position": [
+        -820,
+        -40
+      ]
+    },
+    {
+      "parameters": {
+        "functionCode": "const input = items[0]?.json || {};\nconst tasks = Array.isArray(input.tasks) ? input.tasks : [];\nconst store = this.getWorkflowStaticData('global');\nstore.tasks = tasks;\nreturn [{ json: { domain: input.domain || 'linkedin', tasks } }];"
+      },
+      "id": "e83671b5-9291-47be-9bfa-ca79198f9b25",
+      "name": "Function - Extract Tasks",
+      "type": "n8n-nodes-base.function",
+      "typeVersion": 2,
+      "position": [
+        -600,
+        -40
+      ]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "number": [
+            {
+              "value1": "={{$json.tasks.length}}",
+              "operation": "larger",
+              "value2": 0
+            }
+          ]
+        }
+      },
+      "id": "831eeaa9-264a-4d41-a28e-027dd0338fe0",
+      "name": "IF - Has Tasks",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [
+        -420,
+        -40
+      ]
+    },
+    {
+      "parameters": {
+        "functionCode": "const tasks = items[0].json.tasks || [];\nreturn tasks.map(task => ({ json: task }));"
+      },
+      "id": "35602457-3698-40b6-9b3a-65f6b7257c81",
+      "name": "Function - Fan Out",
+      "type": "n8n-nodes-base.function",
+      "typeVersion": 2,
+      "position": [
+        -220,
+        -140
+      ]
+    },
+    {
+      "parameters": {
+        "propertyName": "action",
+        "dataType": "string",
+        "rules": [
+          {
+            "operation": "equal",
+            "value": "capture_inbox"
+          },
+          {
+            "operation": "equal",
+            "value": "send_message"
+          },
+          {
+            "operation": "equal",
+            "value": "post_update"
+          },
+          {
+            "operation": "equal",
+            "value": "sync_profile"
+          }
+        ]
+      },
+      "id": "efdd7403-ed0d-4452-a644-887aa4182601",
+      "name": "Switch - Route Action",
+      "type": "n8n-nodes-base.switch",
+      "typeVersion": 2,
+      "position": [
+        0,
+        -140
+      ]
+    },
+    {
+      "parameters": {
+        "url": "={{`https://api.apify.com/v2/actor-tasks/${$env.APIFY_LINKEDIN_INBOX_TASK}/run-sync`}}",
+        "method": "POST",
+        "sendQuery": true,
+        "queryParameters": {
+          "parameters": [
+            {
+              "name": "token",
+              "value": "={{$env.APIFY_TOKEN}}"
+            }
+          ]
+        },
+        "jsonParameters": true,
+        "options": {
+          "timeout": 300000
+        },
+        "bodyParametersJson": "={{ JSON.stringify($json.metadata || {}) }}"
+      },
+      "id": "5e14e976-6f6b-40a8-bf1f-0ccbb2358645",
+      "name": "Apify - Capture Inbox",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4,
+      "position": [
+        220,
+        -320
+      ]
+    },
+    {
+      "parameters": {
+        "url": "={{$env.LINKEDIN_AUTOMATION_URL}}/messages",
+        "method": "POST",
+        "jsonParameters": true,
+        "bodyParametersJson": "={{ JSON.stringify({ recipient: $json.metadata.profileId, body: $json.metadata.body, subject: $json.metadata.subject, attachments: $json.metadata.attachments }) }}",
+        "authentication": "headerAuth",
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Authorization",
+              "value": "={{`Bearer ${$env.LINKEDIN_AUTOMATION_TOKEN}`}}"
+            }
+          ]
+        }
+      },
+      "id": "fd0762e3-0ebb-4ce6-81a2-fb9163f5ecd2",
+      "name": "HTTP - Send DM",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4,
+      "position": [
+        220,
+        -160
+      ]
+    },
+    {
+      "parameters": {
+        "url": "={{$env.LINKEDIN_AUTOMATION_URL}}/posts",
+        "method": "POST",
+        "jsonParameters": true,
+        "bodyParametersJson": "={{ JSON.stringify({ body: $json.metadata.body, visibility: $json.metadata.visibility || 'CONNECTIONS', media: $json.metadata.media }) }}",
+        "authentication": "headerAuth",
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Authorization",
+              "value": "={{`Bearer ${$env.LINKEDIN_AUTOMATION_TOKEN}`}}"
+            }
+          ]
+        }
+      },
+      "id": "626d234e-2118-4ff9-b609-64ce4a2d8a8a",
+      "name": "HTTP - Publish Update",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4,
+      "position": [
+        220,
+        0
+      ]
+    },
+    {
+      "parameters": {
+        "url": "={{$env.LINKEDIN_AUTOMATION_URL}}/profiles/{{$json.metadata.profileId}}",
+        "method": "GET",
+        "authentication": "headerAuth",
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Authorization",
+              "value": "={{`Bearer ${$env.LINKEDIN_AUTOMATION_TOKEN}`}}"
+            }
+          ]
+        }
+      },
+      "id": "b903b35f-deaf-42bc-9b38-34de7fba4f3b",
+      "name": "HTTP - Sync Profile",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4,
+      "position": [
+        220,
+        160
+      ]
+    },
+    {
+      "parameters": {
+        "functionCode": "const store = this.getWorkflowStaticData('global');\nreturn items.map(item => {\n  const index = item.pairedItem?.item ?? 0;\n  const source = store.tasks?.[index] || {};\n  return { json: { domain: source.domain || 'linkedin', action: source.action, task: source, result: item.json } };\n});"
+      },
+      "id": "4a8b37d0-7979-46f5-b80e-e4cf2ad4a031",
+      "name": "Function - Format Action Result",
+      "type": "n8n-nodes-base.function",
+      "typeVersion": 2,
+      "position": [
+        460,
+        -120
+      ]
+    },
+    {
+      "parameters": {
+        "values": {
+          "string": [
+            {
+              "name": "domain",
+              "value": "linkedin"
+            }
+          ],
+          "json": [
+            {
+              "name": "result",
+              "value": "={\"status\":\"skipped\",\"reason\":\"No LinkedIn tasks queued.\"}"
+            }
+          ]
+        }
+      },
+      "id": "694c9e29-e087-4cdb-b2de-24fb237084e5",
+      "name": "Set - No Tasks",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 2,
+      "position": [
+        -220,
+        60
+      ]
+    }
+  ],
+  "connections": {
+    "Workflow Trigger": {
+      "main": [
+        [
+          {
+            "node": "Function - Extract Tasks",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Function - Extract Tasks": {
+      "main": [
+        [
+          {
+            "node": "IF - Has Tasks",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "IF - Has Tasks": {
+      "main": [
+        [
+          {
+            "node": "Function - Fan Out",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Set - No Tasks",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Function - Fan Out": {
+      "main": [
+        [
+          {
+            "node": "Switch - Route Action",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Switch - Route Action": {
+      "main": [
+        [
+          {
+            "node": "Apify - Capture Inbox",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "HTTP - Send DM",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "HTTP - Publish Update",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "HTTP - Sync Profile",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Apify - Capture Inbox": {
+      "main": [
+        [
+          {
+            "node": "Function - Format Action Result",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "HTTP - Send DM": {
+      "main": [
+        [
+          {
+            "node": "Function - Format Action Result",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "HTTP - Publish Update": {
+      "main": [
+        [
+          {
+            "node": "Function - Format Action Result",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "HTTP - Sync Profile": {
+      "main": [
+        [
+          {
+            "node": "Function - Format Action Result",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Set - No Tasks": {
+      "main": [
+        [
+          {
+            "node": "Function - Format Action Result",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "pinData": {}
+}

--- a/workflows/twitter-mcp-tools.json
+++ b/workflows/twitter-mcp-tools.json
@@ -1,0 +1,345 @@
+{
+  "name": "Twitter MCP Tools",
+  "nodes": [
+    {
+      "parameters": {},
+      "id": "7615ed87-22e0-4130-82b6-3890d16a6c67",
+      "name": "Workflow Trigger",
+      "type": "n8n-nodes-base.workflowTrigger",
+      "typeVersion": 1,
+      "position": [
+        -820,
+        -40
+      ]
+    },
+    {
+      "parameters": {
+        "functionCode": "const input = items[0]?.json || {};\nconst tasks = Array.isArray(input.tasks) ? input.tasks : [];\nconst store = this.getWorkflowStaticData('global');\nstore.tasks = tasks;\nreturn [{ json: { domain: input.domain || 'twitter', tasks } }];"
+      },
+      "id": "ae7da746-bd95-4789-a542-b3e25b64ddeb",
+      "name": "Function - Extract Tasks",
+      "type": "n8n-nodes-base.function",
+      "typeVersion": 2,
+      "position": [
+        -600,
+        -40
+      ]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "number": [
+            {
+              "value1": "={{$json.tasks.length}}",
+              "operation": "larger",
+              "value2": 0
+            }
+          ]
+        }
+      },
+      "id": "0392d365-5265-4730-b5a0-4024fb19d124",
+      "name": "IF - Has Tasks",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [
+        -420,
+        -40
+      ]
+    },
+    {
+      "parameters": {
+        "functionCode": "const tasks = items[0].json.tasks || [];\nreturn tasks.map(task => ({ json: task }));"
+      },
+      "id": "c50eadac-8372-4d39-9dc1-79cfb1c8b925",
+      "name": "Function - Fan Out",
+      "type": "n8n-nodes-base.function",
+      "typeVersion": 2,
+      "position": [
+        -220,
+        -140
+      ]
+    },
+    {
+      "parameters": {
+        "propertyName": "action",
+        "dataType": "string",
+        "rules": [
+          {
+            "operation": "equal",
+            "value": "post_tweet"
+          },
+          {
+            "operation": "equal",
+            "value": "send_dm"
+          },
+          {
+            "operation": "equal",
+            "value": "search_mentions"
+          },
+          {
+            "operation": "equal",
+            "value": "refresh_metrics"
+          }
+        ]
+      },
+      "id": "3b70b800-52a5-419b-a9b7-09d16d6f0b35",
+      "name": "Switch - Route Action",
+      "type": "n8n-nodes-base.switch",
+      "typeVersion": 2,
+      "position": [
+        0,
+        -140
+      ]
+    },
+    {
+      "parameters": {
+        "resource": "tweet",
+        "operation": "create",
+        "text": "={{$json.metadata.body}}",
+        "additionalFields": {
+          "mediaIds": "={{$json.metadata.mediaIds}}",
+          "replyToTweetId": "={{$json.metadata.replyTo}}"
+        }
+      },
+      "id": "303591c6-1551-4fdf-95a0-4e21867d50ba",
+      "name": "Twitter - Post Tweet",
+      "type": "n8n-nodes-base.twitter",
+      "typeVersion": 2,
+      "position": [
+        220,
+        -320
+      ]
+    },
+    {
+      "parameters": {
+        "resource": "directMessage",
+        "operation": "create",
+        "recipientId": "={{$json.metadata.recipientId}}",
+        "text": "={{$json.metadata.body}}"
+      },
+      "id": "8d754c50-a6ca-4886-8eb9-e4c07c61d116",
+      "name": "Twitter - Send DM",
+      "type": "n8n-nodes-base.twitter",
+      "typeVersion": 2,
+      "position": [
+        220,
+        -160
+      ]
+    },
+    {
+      "parameters": {
+        "resource": "tweet",
+        "operation": "search",
+        "query": "={{$json.metadata.query || `@${$env.TWITTER_HANDLE}`}}",
+        "returnAll": false,
+        "limit": "={{$json.metadata.limit || 20}}"
+      },
+      "id": "6bd87f29-f696-4e79-9a6e-a4da30fe48f7",
+      "name": "Twitter - Search Mentions",
+      "type": "n8n-nodes-base.twitter",
+      "typeVersion": 2,
+      "position": [
+        220,
+        0
+      ]
+    },
+    {
+      "parameters": {
+        "resource": "tweet",
+        "operation": "get",
+        "tweetId": "={{$json.metadata.tweetId}}"
+      },
+      "id": "bc1493f3-d3a5-47c7-a42b-022dd92df8f3",
+      "name": "Twitter - Refresh Metrics",
+      "type": "n8n-nodes-base.twitter",
+      "typeVersion": 2,
+      "position": [
+        220,
+        160
+      ]
+    },
+    {
+      "parameters": {
+        "functionCode": "const store = this.getWorkflowStaticData('global');\nreturn items.map(item => {\n  const index = item.pairedItem?.item ?? 0;\n  const source = store.tasks?.[index] || {};\n  return { json: { domain: source.domain || 'twitter', action: source.action, task: source, result: item.json } };\n});"
+      },
+      "id": "8f1c1312-5356-48ad-a306-9a76b1b31f6a",
+      "name": "Function - Format Action Result",
+      "type": "n8n-nodes-base.function",
+      "typeVersion": 2,
+      "position": [
+        460,
+        -120
+      ]
+    },
+    {
+      "parameters": {
+        "values": {
+          "string": [
+            {
+              "name": "domain",
+              "value": "twitter"
+            }
+          ],
+          "json": [
+            {
+              "name": "result",
+              "value": "={\"status\":\"skipped\",\"reason\":\"No Twitter tasks queued.\"}"
+            }
+          ]
+        }
+      },
+      "id": "f3962eeb-58e6-4fda-8905-1ace7538cfb9",
+      "name": "Set - No Tasks",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 2,
+      "position": [
+        -220,
+        60
+      ]
+    }
+  ],
+  "connections": {
+    "Workflow Trigger": {
+      "main": [
+        [
+          {
+            "node": "Function - Extract Tasks",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Function - Extract Tasks": {
+      "main": [
+        [
+          {
+            "node": "IF - Has Tasks",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "IF - Has Tasks": {
+      "main": [
+        [
+          {
+            "node": "Function - Fan Out",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Set - No Tasks",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Function - Fan Out": {
+      "main": [
+        [
+          {
+            "node": "Switch - Route Action",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Switch - Route Action": {
+      "main": [
+        [
+          {
+            "node": "Twitter - Post Tweet",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Twitter - Send DM",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Twitter - Search Mentions",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Twitter - Refresh Metrics",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Twitter - Post Tweet": {
+      "main": [
+        [
+          {
+            "node": "Function - Format Action Result",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Twitter - Send DM": {
+      "main": [
+        [
+          {
+            "node": "Function - Format Action Result",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Twitter - Search Mentions": {
+      "main": [
+        [
+          {
+            "node": "Function - Format Action Result",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Twitter - Refresh Metrics": {
+      "main": [
+        [
+          {
+            "node": "Function - Format Action Result",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Set - No Tasks": {
+      "main": [
+        [
+          {
+            "node": "Function - Format Action Result",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "pinData": {}
+}

--- a/workflows/utility-mcp-tools.json
+++ b/workflows/utility-mcp-tools.json
@@ -1,0 +1,360 @@
+{
+  "name": "Utility MCP Tools",
+  "nodes": [
+    {
+      "parameters": {},
+      "id": "1f191637-caec-4e2a-94af-bc14924e8ebb",
+      "name": "Workflow Trigger",
+      "type": "n8n-nodes-base.workflowTrigger",
+      "typeVersion": 1,
+      "position": [
+        -820,
+        -20
+      ]
+    },
+    {
+      "parameters": {
+        "functionCode": "const input = items[0]?.json || {};\nconst tasks = Array.isArray(input.tasks) ? input.tasks : [];\nconst store = this.getWorkflowStaticData('global');\nstore.tasks = tasks;\nreturn [{ json: { domain: input.domain || 'utility', tasks } }];"
+      },
+      "id": "6f0c1546-ed68-4cb9-bdb6-512aafa7c0df",
+      "name": "Function - Extract Tasks",
+      "type": "n8n-nodes-base.function",
+      "typeVersion": 2,
+      "position": [
+        -600,
+        -20
+      ]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "number": [
+            {
+              "value1": "={{$json.tasks.length}}",
+              "operation": "larger",
+              "value2": 0
+            }
+          ]
+        }
+      },
+      "id": "996a438a-112b-4ade-b1c6-4c1e268a05d3",
+      "name": "IF - Has Tasks",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [
+        -420,
+        -20
+      ]
+    },
+    {
+      "parameters": {
+        "functionCode": "const tasks = items[0].json.tasks || [];\nreturn tasks.map(task => ({ json: task }));"
+      },
+      "id": "2b634964-e7f8-4aa6-a63a-854dee8f6128",
+      "name": "Function - Fan Out",
+      "type": "n8n-nodes-base.function",
+      "typeVersion": 2,
+      "position": [
+        -220,
+        -120
+      ]
+    },
+    {
+      "parameters": {
+        "propertyName": "action",
+        "dataType": "string",
+        "rules": [
+          {
+            "operation": "equal",
+            "value": "summarize_notes"
+          },
+          {
+            "operation": "equal",
+            "value": "enrich_lead"
+          },
+          {
+            "operation": "equal",
+            "value": "sync_airtable"
+          },
+          {
+            "operation": "equal",
+            "value": "notify_team"
+          }
+        ]
+      },
+      "id": "17928f80-f4cb-40a1-b935-c36999476953",
+      "name": "Switch - Route Action",
+      "type": "n8n-nodes-base.switch",
+      "typeVersion": 2,
+      "position": [
+        0,
+        -120
+      ]
+    },
+    {
+      "parameters": {
+        "resource": "chat",
+        "operation": "chat",
+        "model": "gpt-4o-mini",
+        "messages": [
+          {
+            "message": "Summarize these notes into crisp bullets with owners and due dates: {{$json.metadata.notes}}",
+            "sender": "user"
+          }
+        ]
+      },
+      "id": "2fe0b60c-f41a-4160-a84c-5865f4c305c4",
+      "name": "OpenAI - Summarize Notes",
+      "type": "n8n-nodes-base.openAi",
+      "typeVersion": 3,
+      "position": [
+        220,
+        -300
+      ]
+    },
+    {
+      "parameters": {
+        "operation": "person",
+        "email": "={{$json.metadata.email}}"
+      },
+      "id": "a566344c-9e51-4f09-b845-7794cdce1c28",
+      "name": "Clearbit - Enrich Lead",
+      "type": "n8n-nodes-base.clearbit",
+      "typeVersion": 1,
+      "position": [
+        220,
+        -140
+      ]
+    },
+    {
+      "parameters": {
+        "operation": "update",
+        "application": "={{$env.AIRTABLE_APP_ID}}",
+        "table": "={{$env.AIRTABLE_PIPELINE_TABLE}}",
+        "id": "={{$json.metadata.recordId}}",
+        "updateAllFields": true,
+        "fieldsUi": {
+          "fieldValues": [
+            {
+              "fieldId": "={{$json.metadata.statusField || 'Status'}}",
+              "fieldValue": "={{$json.metadata.status}}"
+            },
+            {
+              "fieldId": "={{$json.metadata.nextStepField || 'Next Step'}}",
+              "fieldValue": "={{$json.metadata.nextStep}}"
+            }
+          ]
+        }
+      },
+      "id": "748f92e0-7e53-45ca-a63e-46b0d25e8db0",
+      "name": "Airtable - Sync Record",
+      "type": "n8n-nodes-base.airtable",
+      "typeVersion": 2,
+      "position": [
+        220,
+        0
+      ]
+    },
+    {
+      "parameters": {
+        "operation": "message",
+        "channel": "={{$env.SLACK_ALERT_CHANNEL}}",
+        "text": "={{$json.metadata.message}}",
+        "additionalFields": {
+          "mrkdwn": true
+        }
+      },
+      "id": "9f59ebbd-18bd-4dee-b9d3-d665394bb81a",
+      "name": "Slack - Notify Team",
+      "type": "n8n-nodes-base.slack",
+      "typeVersion": 1,
+      "position": [
+        220,
+        160
+      ]
+    },
+    {
+      "parameters": {
+        "functionCode": "const store = this.getWorkflowStaticData('global');\nreturn items.map(item => {\n  const index = item.pairedItem?.item ?? 0;\n  const source = store.tasks?.[index] || {};\n  return { json: { domain: source.domain || 'utility', action: source.action, task: source, result: item.json } };\n});"
+      },
+      "id": "ad96ebca-8350-472f-a85c-abc91e867abb",
+      "name": "Function - Format Action Result",
+      "type": "n8n-nodes-base.function",
+      "typeVersion": 2,
+      "position": [
+        460,
+        -120
+      ]
+    },
+    {
+      "parameters": {
+        "values": {
+          "string": [
+            {
+              "name": "domain",
+              "value": "utility"
+            }
+          ],
+          "json": [
+            {
+              "name": "result",
+              "value": "={\"status\":\"skipped\",\"reason\":\"No utility tasks queued.\"}"
+            }
+          ]
+        }
+      },
+      "id": "c44f8dc0-ede6-4963-8b07-f9c45762d283",
+      "name": "Set - No Tasks",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 2,
+      "position": [
+        -220,
+        80
+      ]
+    }
+  ],
+  "connections": {
+    "Workflow Trigger": {
+      "main": [
+        [
+          {
+            "node": "Function - Extract Tasks",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Function - Extract Tasks": {
+      "main": [
+        [
+          {
+            "node": "IF - Has Tasks",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "IF - Has Tasks": {
+      "main": [
+        [
+          {
+            "node": "Function - Fan Out",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Set - No Tasks",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Function - Fan Out": {
+      "main": [
+        [
+          {
+            "node": "Switch - Route Action",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Switch - Route Action": {
+      "main": [
+        [
+          {
+            "node": "OpenAI - Summarize Notes",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Clearbit - Enrich Lead",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Airtable - Sync Record",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Slack - Notify Team",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "OpenAI - Summarize Notes": {
+      "main": [
+        [
+          {
+            "node": "Function - Format Action Result",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Clearbit - Enrich Lead": {
+      "main": [
+        [
+          {
+            "node": "Function - Format Action Result",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Airtable - Sync Record": {
+      "main": [
+        [
+          {
+            "node": "Function - Format Action Result",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Slack - Notify Team": {
+      "main": [
+        [
+          {
+            "node": "Function - Format Action Result",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Set - No Tasks": {
+      "main": [
+        [
+          {
+            "node": "Function - Format Action Result",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "pinData": {}
+}


### PR DESCRIPTION
## Summary
- add AI Operations Assistant master workflow orchestrating the AI employee agent and OpenAI planning
- add Google, LinkedIn, Twitter, and utility MCP tool sub-workflows used by the agent
- document import order, required environment variables, and tooling overview in workflows/README.md

## Testing
- not run (workflow JSON only)


------
https://chatgpt.com/codex/tasks/task_e_69090c7d14bc8326af239c5e9e7e2dc7